### PR TITLE
corrected issue with swapped addin title/description

### DIFF
--- a/solidworks-api/getting-started/add-ins/csharp/add-in.cs
+++ b/solidworks-api/getting-started/add-ins/csharp/add-in.cs
@@ -57,8 +57,8 @@ namespace SampleAddIn
 
                 addInkey.SetValue(null, 0);
 
-                addInkey.SetValue(ADD_IN_TITLE_REG_KEY_NAME, addInDesc);
-                addInkey.SetValue(ADD_IN_DESCRIPTION_REG_KEY_NAME, addInTitle);
+                addInkey.SetValue(ADD_IN_TITLE_REG_KEY_NAME, addInTitle);
+                addInkey.SetValue(ADD_IN_DESCRIPTION_REG_KEY_NAME, addInDesc);
 
                 var addInStartupkey = Microsoft.Win32.Registry.CurrentUser.CreateSubKey(
                     string.Format(ADDIN_STARTUP_KEY_TEMPLATE, t.GUID));


### PR DESCRIPTION
The addin showed the description as the title and the title as the description. Made a simple correction to this.