### PR TITLE
Fix missing / in link

### DIFF
--- a/visual-basic/variables/user-defined-types/index.md
+++ b/visual-basic/variables/user-defined-types/index.md
@@ -7,9 +7,10 @@ order: 2
 ---
 
 ## Enumerations
+
 Enumerations are Visual Basic data types which hold sets of integer constants. Enumerations are useful to define family of constants to be used by the developers (i.e. options).
 
-Refer [Enumerations](visual-basic/data-structures/enumerators) article for more information about enumerators.
+Refer [Enumerations](/visual-basic/data-structures/enumerators) article for more information about enumerators.
 
 Enumerators are treated as any other data types and can be declared and assigned. Enumerations can be assigned implicitly and explicitly.
 
@@ -24,16 +25,17 @@ myEnumVal1 = Val1 'implicit assignment of the enumerator
 
 Visual Basic allows to create new data groups. Custom user-defined Type is a data type, also known as *Structure* which allows to define complex data storage. Types are useful when it is required to pass or store the data which consists of multiple elements (e.g. geometrical point, log entry, etc.)
 
-Refer [Custom User Defined Types](visual-basic/data-structures/types) article for more information about custom types.
+Refer [Custom User Defined Types](/visual-basic/data-structures/types) article for more information about custom types.
 
 ## Class
+
 Unlike enumerations and types classes can only be created in separate Visual Basic class modules.
 
 ![MyClass class module is added to the Visual Basic project](class-module-class-declaration.png){ width=500 }
 
 Classes are reference types and must be initiated with *new* keyword and reference must be assigned using *Set* keyword.
 
-Refer [Classes](visual-basic/classes) article for more information about classes.
+Refer [Classes](/visual-basic/classes) article for more information about classes.
 
 Code example below shows how to declare and assign enumerator, type and class.
 


### PR DESCRIPTION
The internal link in [Visual Basic data structures: objects, types, enumerations
](https://www.codestack.net/visual-basic/variables/user-defined-types/) do not render properly.

I hope this PR fix the behavior.